### PR TITLE
Disable image lightbox on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,6 +221,9 @@
             .about-image-caption {
                 font-size: 0.9em !important;
             }
+            .artwork img {
+                cursor: default;
+            }
         }
     </style>
 </head>
@@ -397,6 +400,9 @@
         const lightboxHamburgerMenu = document.querySelector(".lightbox .hamburger-menu");
 
         function openLightbox(img, description) {
+            if (window.innerWidth <= 600) {
+                return;
+            }
             $('#lightbox').fadeIn();
             $('#lightbox-image').attr('src', img.src);
             $('#lightbox-caption').html(description);


### PR DESCRIPTION
## Summary
- disable gallery image zoom on small screens
- remove pointer cursor for gallery images on mobile

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6845c19dd5ac832d832c34f0b8e9b796