### PR TITLE
Update homepage captions

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
         }
         .lightbox-image-container {
             max-width: 90%;
-            max-height: calc(100% - 160px);
+            max-height: calc(100% - 80px);
             display: flex;
             justify-content: center;
             align-items: center;
@@ -98,6 +98,7 @@
             object-fit: contain;
         }
         .lightbox-caption {
+            display: none;
             color: black;
             font-size: 16px;
             max-width: 90%;
@@ -254,99 +255,99 @@
 <div class="gallery" id="gallery">
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-24.jpg" alt="A horizontal abstract painting by artist Caroline Coolidge, featuring three large shapes of dark blue, the most prominent being in the center left and curved, and other sections of fluffy, illustrative white, pale pink, and pale yellow paint." onclick="openLightbox(this, '<i>Life Cycle of a Cumulonimbus</i>, 2025<br>Oil on canvas<br>24 x 30 in')">
-            <p><i>Life Cycle of a Cumulonimbus</i>, 2025</p>
+            <p><i>Life Cycle of a Cumulonimbus</i>, 2025<br>Oil on canvas<br>24 x 30 in</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-23.jpg" alt="A dark, deep, eggplant color dominates this horizontal abstract painting by Caroline Coolidge and includes a dramatic curved, silver pink line that curves down, and across the center of the painting, where it meets other lines and shapes on the right side." onclick="openLightbox(this, '<i>Machine Breath</i>, 2025<br>Oil on canvas<br>30 x 40 in')">
-            <p><i>Machine Breath</i>, 2025</p>
+            <p><i>Machine Breath</i>, 2025<br>Oil on canvas<br>30 x 40 in</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-22.jpg" alt="A vertical abstract painting by Caroline Coolidge with a dark blue smooth, layered bottom left half and a light, blue, turquoise, and lime green section on the top right of interposing layers of paint that resemble light." onclick="openLightbox(this, '<i>Glassine Pigment</i>, 2025<br>Oil on canvas<br>30 x 24 in')">
-            <p><i>Glassine Pigment</i>, 2025</p>
+            <p><i>Glassine Pigment</i>, 2025<br>Oil on canvas<br>30 x 24 in</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-21.jpg" alt="A vertical abstract painting by Caroline Coolidge, the top two-thirds is smooth and ranges in green, tan, orange, and blue tones. The bottom third in dark blue and more textural and rough." onclick="openLightbox(this, '<i>Earth Spill</i>, 2025<br>Oil on canvas<br>40 x 30 in')">
-            <p><i>Earth Spill</i>, 2025</p>
+            <p><i>Earth Spill</i>, 2025<br>Oil on canvas<br>40 x 30 in</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-20.jpg" alt="A vertical painting by artist Caroline Coolidge that is predominantly print and red, with touches of green." onclick="openLightbox(this, '<i>Esophageal Petals</i>, 2025<br>Oil on canvas<br>12 x 9 in')">
-            <p><i>Esophageal Petals</i>, 2025</p>
+            <p><i>Esophageal Petals</i>, 2025<br>Oil on canvas<br>12 x 9 in</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-19.jpg" alt="A square, highly textured abstract painting by Caroline Coolidge that is primarily yellow and down, with textured lines throughout, giving the impression of tree bark." onclick="openLightbox(this, '<i>Ghost Print I</i>, 2025<br>Monofilament polyester screen-printing mesh, acrylic screen-printing paste, powdered pigment, and graphite powder on canvas<br>48 x 48 in')">
-            <p><i>Ghost Print I</i>, 2025</p>
+            <p><i>Ghost Print I</i>, 2025<br>Monofilament polyester screen-printing mesh, acrylic screen-printing paste, powdered pigment, and graphite powder on canvas<br>48 x 48 in</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-18.jpg" alt="A square abstract painting by Caroline Coolidge that is predominantly blue, yellow, and pale gray with wavy lines creating a loose grid." onclick="openLightbox(this, '<i>Ghost Print II</i>, 2025<br>Monofilament polyester screen-printing mesh, acrylic screen-printing paste, powdered pigment, and graphite powder on canvas<br>48 x 48 in')">
-            <p><i>Ghost Print II</i>, 2025</p>
+            <p><i>Ghost Print II</i>, 2025<br>Monofilament polyester screen-printing mesh, acrylic screen-printing paste, powdered pigment, and graphite powder on canvas<br>48 x 48 in</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-17.jpg" alt="A square, abstract, tan painting by Caroline Coolidge, dominated by a large loose square shape in the center and light splotches surrounding it." onclick="openLightbox(this, '<i>Matrix</i>, 2025<br>Monofilament polyester screen-printing mesh, acrylic screen-printing paste, powdered pigment, and graphite powder on canvas<br>48 x 48 in')">
-            <p><i>Matrix</i>, 2025</p>
+            <p><i>Matrix</i>, 2025<br>Monofilament polyester screen-printing mesh, acrylic screen-printing paste, powdered pigment, and graphite powder on canvas<br>48 x 48 in</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-16.jpg" alt="A vertical, translucent, yellow fabric, catching light, cascades from the gallery's white-grey ceiling and rests lightly on the room’s concrete floor, artwork created by Caroline Coolidge." onclick="openLightbox(this, '<i>echoes</i>, 2024<br>Acrylic ink and pigment on screen-printing mesh<br>120 x 50 in')">
-            <p><i>echoes</i>, 2024</p>
+            <p><i>echoes</i>, 2024<br>Acrylic ink and pigment on screen-printing mesh<br>120 x 50 in</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-15.jpg" alt="A long, vertical window covered in translucent layers of painted mesh screens, giving the appearance of a glowing impressionist painting. It is being contemplated by a dark-haired man in a blue shirt who is facing the artwork by Caroline Coolidge." onclick="openLightbox(this, '<i>Facsimile (Window Intervention)</i>, 2024<br>Pigment, graphite, and ink on screen-printing mesh installed over window<br>87 x 33 × 12 in')">
-            <p><i>Facsimile (Window Intervention)</i>, 2024</p>
+            <p><i>Facsimile (Window Intervention)</i>, 2024<br>Pigment, graphite, and ink on screen-printing mesh installed over window<br>87 x 33 × 12 in</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-14.jpg" alt="A close-up of highly textured layers of transparent painted fabric with light shining from behind. Artwork by Caroline Coolidge." onclick="openLightbox(this, '<i>Facsimile (Window Intervention)</i>, 2024<br>Pigment, graphite, and ink on screen-printing mesh installed over window<br>Detail')">
-            <p><i>Facsimile (Window Intervention)</i>, 2024</p>
+            <p><i>Facsimile (Window Intervention)</i>, 2024<br>Pigment, graphite, and ink on screen-printing mesh installed over window<br>Detail</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-13.jpg" alt="Photograph of a white gallery wall with a blue abstract painting, by artist Caroline Coolidge, hung vertically in the center right of the composition and an artfully arranged pile of blue and green painted mesh fabrics on the floor, corresponding to the painting." onclick="openLightbox(this, '<i>Parallel Memory</i>, 2024<br>Installation view, Ruskin School of Art Project Space, University of Oxford<br>Oxford, England, UK')">
-            <p><i>Parallel Memory</i>, 2024</p>
+            <p><i>Parallel Memory</i>, 2024<br>Installation view, Ruskin School of Art Project Space, University of Oxford<br>Oxford, England, UK</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-12.jpg" alt="Photograph showing a closely cropped view of overlapping, bunched up mesh screens on a light-grey floor in four distinct shades of light and dark, blue and green. Artwork by Caroline Coolidge." onclick="openLightbox(this, '<i>Prototypes</i>, 2024<br>Installation view (detail), Ruskin School of Art Project Space, University of Oxford<br>Oxford, England, UK')">
-            <p><i>Prototypes</i>, 2024</p>
+            <p><i>Prototypes</i>, 2024<br>Installation view (detail), Ruskin School of Art Project Space, University of Oxford<br>Oxford, England, UK</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-11.jpg" alt="A large, vertical, green, textural sculpture by Caroline Coolidge, resting on a light grey gallery floor with a white wall behind it, made out of a translucent fabric material, shiny in some sections." onclick="openLightbox(this, '<i>Flux</i>, 2024<br>Pigment, ink, and resin on screen-printing mesh<br>62 x 30 x 28 in')">
-            <p><i>Flux</i>, 2024</p>
+            <p><i>Flux</i>, 2024<br>Pigment, ink, and resin on screen-printing mesh<br>62 x 30 x 28 in</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-10.jpg" alt="Photograph of a vertical, dark-blue and black sublime abstract painting by artist Caroline Coolidge, hung on a white wall." onclick="openLightbox(this, '<i>Parallel Memory</i>, 2024<br>Pigment, ink, and acrylic on board<br>33 x 23 in')">
-            <p><i>Parallel Memory</i>, 2024</p>
+            <p><i>Parallel Memory</i>, 2024<br>Pigment, ink, and acrylic on board<br>33 x 23 in</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-09.jpg" alt="A vertical grey painting by Caroline Coolidge with light, chalky grey in the foreground and subtle strokes that create lines dividing the painting into four equal quadrants." onclick="openLightbox(this, '<i>Screening Memory (Toxic Impression I)</i>, 2024<br>Acrylic, graphite, and pigment on board<br>33 x 23 in')">
-            <p><i>Screening Memory (Toxic Impression I)</i>, 2024</p>
+            <p><i>Screening Memory (Toxic Impression I)</i>, 2024<br>Acrylic, graphite, and pigment on board<br>33 x 23 in</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-08.jpg" alt="An atmospheric, lime green and grey green, vertical, abstract painting by Caroline Coolidge with subtle marks primarily drawn at right angles to the painting’s edge." onclick="openLightbox(this, '<i>Screening Memory (Toxic Impression II)</i>, 2024<br>Acrylic, graphite, pigment, and colored pencil on board<br>33 x 23 in')">
-            <p><i>Screening Memory (Toxic Impression II)</i>, 2024</p>
+            <p><i>Screening Memory (Toxic Impression II)</i>, 2024<br>Acrylic, graphite, pigment, and colored pencil on board<br>33 x 23 in</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-07.jpg" alt="A horizontal abstract painting by Caroline Coolidge with a dark grey base and translucent light tan, pink, and yellow layers obscuring darker sections below." onclick="openLightbox(this, '<i>Setting Trees</i>, 2024<br>Oil, acrylic, and graphite on paper<br>22 x 30 in')">
-            <p><i>Setting Trees</i>, 2024</p>
+            <p><i>Setting Trees</i>, 2024<br>Oil, acrylic, and graphite on paper<br>22 x 30 in</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-06.jpg" alt="A moody vertical abstract painting by Caroline Coolidge on light paper, primarily composed of grey and purple marks in the bottom half of the composition, an orange grey in the top left, and dark red purple in the top right." onclick="openLightbox(this, '<i>Reflection in Smog (of Mirrors and Moss)</i>, 2024<br>Pigment, graphite, ink, oil, and screen print on paper<br>22 x 15 in')">
-            <p><i>Reflection in Smog (of Mirrors and Moss)</i>, 2024</p>
+            <p><i>Reflection in Smog (of Mirrors and Moss)</i>, 2024<br>Pigment, graphite, ink, oil, and screen print on paper<br>22 x 15 in</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-05.jpg" alt="A dynamic vertical black and white drawing by Caroline Coolidge, with two dark grey and black textural, rectangular shapes in the center of a white and grey background, giving the sense of movement upwards." onclick="openLightbox(this, '<i>Screen Impressions VII</i>, 2024<br>Graphite, charcoal, and acrylic medium on paper mounted on board<br>22 x 15 in')">
-            <p><i>Screen Impressions VII</i>, 2024</p>
+            <p><i>Screen Impressions VII</i>, 2024<br>Graphite, charcoal, and acrylic medium on paper mounted on board<br>22 x 15 in</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-04.jpg" alt="A vertical black and white drawing by Caroline Coolidge, with dark blacks and grey abstract shapes swirling around the top half of the composition and light grey and white marks in the bottom." onclick="openLightbox(this, '<i>Screen Impressions IX</i>, 2024<br>Graphite, charcoal, and acrylic medium on paper mounted on board<br>22 x 15 in')">
-            <p><i>Screen Impressions IX</i>, 2024</p>
+            <p><i>Screen Impressions IX</i>, 2024<br>Graphite, charcoal, and acrylic medium on paper mounted on board<br>22 x 15 in</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-03.jpg" alt="A photograph of a large, black and white, abstract, highly textural, charcoal drawing, installed between two white slanted metal beams and rolled up at the bottom, seen from an angled view, with the top of the drawing cut off, with two smaller light grey prints on the concrete floor beneath it. Art installation by Caroline Coolidge." onclick="openLightbox(this, '<i>The Unfelt Pressure Between the Body and the Screen</i>, 2023<br>Installation view, Ruskin School of Art Project Space, University of Oxford<br>Oxford, England, UK')">
-            <p><i>The Unfelt Pressure Between the Body and the Screen</i>, 2023</p>
+            <p><i>The Unfelt Pressure Between the Body and the Screen</i>, 2023<br>Installation view, Ruskin School of Art Project Space, University of Oxford<br>Oxford, England, UK</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-02.jpg" alt="A large screen with a black, white, and yellow animation still of abstract lines resembling tree limbs by artist Caroline Coolidge. The screen has speakers on the left and right sides of it and has a tan table with paper stacked on it." onclick="openLightbox(this, '<i>re/de/constructed language</i>, 2022<br>Installation view, Carpenter Center for the Visual Arts at Harvard University<br>Cambridge, MA, USA')">
-            <p><i>re/de/constructed language</i>, 2022</p>
+            <p><i>re/de/constructed language</i>, 2022<br>Installation view, Carpenter Center for the Visual Arts at Harvard University<br>Cambridge, MA, USA</p>
         </div>
         <div class="artwork">
             <img src="art3/Caroline-Coolidge-Artist-Website-01.jpg" alt="A gallery space with an art installation by Caroline Coolidge comprised of a projected image on a screen mounted to the far right wall, a table with stacks of paper on it, abstract paintings on wood and paper stacked on the shiny concrete floor, and a large abstract book form resting on a medium-high table to the back-left of the works on the floor." onclick="openLightbox(this, '<i>re/de/constructed language</i>, 2022<br>Installation view, Carpenter Center for the Visual Arts at Harvard University<br>Cambridge, MA, USA')">
-            <p><i>re/de/constructed language</i>, 2022</p>
+            <p><i>re/de/constructed language</i>, 2022<br>Installation view, Carpenter Center for the Visual Arts at Harvard University<br>Cambridge, MA, USA</p>
 </div>
 
 
@@ -384,7 +385,6 @@
             }
             $('#lightbox').fadeIn();
             $('#lightbox-image').attr('src', img.src);
-            $('#lightbox-caption').html(description);
             $('body').css('overflow', 'hidden');
             lightboxHamburgerMenu.classList.add("change");
         }


### PR DESCRIPTION
## Summary
- display artwork captions directly on the homepage
- hide captions in the lightbox and allow more space for images

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845c48fe8a0832da9e512f0704c2bf8