### PR TITLE
Fix homepage link styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,6 @@
         .name {
             font-size: 28px;
             /* font-weight: bold; */
-            cursor: pointer;
             text-align: center;
             margin-top: 10px;
         }
@@ -42,7 +41,12 @@
           text-decoration: none;
         }
         a:hover {
-          color: #EE5C35;
+            color: #EE5C35;
+        }
+        .name a,
+        .name a:hover {
+            color: inherit;
+            cursor: default;
         }
         .gallery, .about-content {
             max-width: 1000px;


### PR DESCRIPTION
## Summary
- remove pointer styling from the site title
- stop hover color on the site title so only the About link highlights

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845c9b0866c832d8158dc18e47d140a