### PR TITLE
Reduce gap between portrait and bio

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@
         }
         .about-content {
             display: flex;
-            gap: 40px;
+            gap: 20px;
         }
         .about-left, .about-right {
             flex: 1;


### PR DESCRIPTION
## Summary
- make the space between the portrait and bio smaller on the About page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845cefdff4c832da303d748c98c61d9