### PR TITLE
Align about page caption and contact

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,6 +222,16 @@
             margin-top: 12px;
             margin-bottom: 60px;
         }
+        .about-credits {
+            display: flex;
+            gap: 40px;
+        }
+        .about-credits p {
+            flex: 1;
+        }
+        .about-contact {
+            text-align: left;
+        }
         @media (max-width: 600px) {
             body {
                 padding: 0;
@@ -261,6 +271,9 @@
                 margin-bottom: 0;
             }
             .about-content {
+                flex-direction: column;
+            }
+            .about-credits {
                 flex-direction: column;
             }
             .artwork img {
@@ -384,7 +397,6 @@
     <div class="about-content" style="display: none;">
         <div class="about-left">
             <img src="art3/Caroline-Coolidge-in-her-studio.jpg" alt="Caroline Coolidge in her studio" class="about-image">
-            <p class="about-image-caption">Portrait by Deema Alghunaim, 2024.</p>
         </div>
         <div class="about-right">
             <p>Caroline Coolidge is driven by investigations of the ephemeral. She explores what occurs at the edge of materials and ideas. Coolidge traces her practice to the blur between painting and printmaking. Her works are remnants of unexpected applications of process and tools, and embody the unraveling that occurs with their creation. Through abstraction, Coolidge creates a sense of disorientation. She forms uncertain memories by considering the history of image creation and reflects upon the breakdown of reality and stability, permeating the present, through her breakdown of the visual past.</p>
@@ -392,9 +404,12 @@
             <p>Coolidge’s practice is based in Edinburgh, Scotland. Recent solo exhibitions include <i>As Smoke Loses Itself in Air</i>, Patriothall Gallery, Edinburgh, Scotland (forthcoming); <i>Dismantling the Screen</i>, Dolphin Gallery at St John's College, Oxford, England, 2024; and <i>re/de/constructed language</i>, Spoke Gallery, Boston, USA, 2022. </p>
 
             <p>Coolidge has worked as a teaching fellow in the Art, Film, and Visual Studies department at Harvard University, has been a Curatorial Research Fellow at the MIT List Visual Arts Center, and has held residencies at the Vermont Studio Center and the Salzburg International Summer Academy of Fine Arts. She completed her undergraduate studies at Harvard College in 2022 and earned a Master of Fine Arts with distinction from the Ruskin School of Art, University of Oxford, in 2024.</p>
-
-            <p>Contact: studio@carolinecoolidge.com</p>
         </div>
+    </div>
+
+    <div class="about-credits" style="display: none;">
+        <p class="about-image-caption">Portrait by Deema Alghunaim, 2024.</p>
+        <p class="about-contact">Contact: studio@carolinecoolidge.com</p>
     </div>
 
     <div class="lightbox" id="lightbox">
@@ -436,7 +451,7 @@
         const aboutHamburgerMenu = document.querySelector(".menu .hamburger-menu");
         function showAbout() {
             $('#gallery').hide();
-            $('.about-content').show();
+            $('.about-content, .about-credits').show();
             
             document.querySelector("#aboutLink").classList.add("change");
             aboutHamburgerMenu.classList.add("change");
@@ -444,7 +459,7 @@
         }
         
         function showGallery() {
-            $('.about-content').hide();
+            $('.about-content, .about-credits').hide();
             $('#gallery').show();
             if (document.querySelector("#aboutLink").classList.contains("change")) {
                 document.querySelector("#aboutLink").classList.remove("change");


### PR DESCRIPTION
## Summary
- add a flex row for the about page portrait credit and contact info
- ensure about section JS toggles the new row
- update responsive styles

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6845cf3b52e8832d91d674e0209cc0e3