### PR TITLE
Fix about page X alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,7 +158,12 @@
         }
         .menu .hamburger-menu {
             position: absolute;
-            top: 50%;
+            /*
+             * Place the hamburger/X icon vertically in line with the
+             * artist name below. The menu sits above the name so we
+             * offset the icon slightly downward.
+             */
+            top: calc(50% + 30px);
             transform: translateY(-50%);
             cursor: pointer;
             right: 0;


### PR DESCRIPTION
## Summary
- shift hamburger/X icon downward so it lines up with "Caroline Coolidge" on the About page

## Testing
- `chromium-browser --headless --disable-gpu --screenshot=/tmp/screenshot.png index.html` *(fails: requires snap)*

------
https://chatgpt.com/codex/tasks/task_e_6845cf8736ec832d8234e28408378208