### PR TITLE
Update about text size on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,10 +257,10 @@
                 font-size: 14px;
             }
             .about-content p {
-                font-size: 16px;
+                font-size: 14px;
             }
             .about-image-caption {
-                font-size: 0.9em !important;
+                font-size: 0.8em !important;
                 margin-bottom: 20px;
             }
             .about-right p {


### PR DESCRIPTION
## Summary
- use 14px font on the about paragraph for small screens

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6845d0499e4c832d90a9082f29acd492