### PR TITLE
Update about page layout and contact info

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,7 +216,7 @@
             text-align: center;
         }
         .about-image {
-            width: 80%;
+            width: 85%;
             height: auto;
             display: block;
             margin: 0 auto;
@@ -224,18 +224,8 @@
         .about-image-caption {
             font-size: 0.95em !important;
             text-align: center;
-            margin-top: 12px;
+            margin-top: 8px;
             margin-bottom: 60px;
-        }
-        .about-credits {
-            display: flex;
-            gap: 40px;
-        }
-        .about-credits p {
-            flex: 1;
-        }
-        .about-contact {
-            text-align: left;
         }
         @media (max-width: 600px) {
             body {
@@ -282,9 +272,6 @@
                 width: 100%;
             }
             .about-content {
-                flex-direction: column;
-            }
-            .about-credits {
                 flex-direction: column;
             }
             .artwork img {
@@ -408,6 +395,7 @@
     <div class="about-content" style="display: none;">
         <div class="about-left">
             <img src="art3/Caroline-Coolidge-in-her-studio.jpg" alt="Caroline Coolidge in her studio" class="about-image">
+        <p class="about-image-caption">Portrait by Deema Alghunaim, 2024.</p>
         </div>
         <div class="about-right">
             <p>Caroline Coolidge is driven by investigations of the ephemeral. She explores what occurs at the edge of materials and ideas. Coolidge traces her practice to the blur between painting and printmaking. Her works are remnants of unexpected applications of process and tools, and embody the unraveling that occurs with their creation. Through abstraction, Coolidge creates a sense of disorientation. She forms uncertain memories by considering the history of image creation and reflects upon the breakdown of reality and stability, permeating the present, through her breakdown of the visual past.</p>
@@ -415,13 +403,10 @@
             <p>Coolidge’s practice is based in Edinburgh, Scotland. Recent solo exhibitions include <i>As Smoke Loses Itself in Air</i>, Patriothall Gallery, Edinburgh, Scotland (forthcoming); <i>Dismantling the Screen</i>, Dolphin Gallery at St John's College, Oxford, England, 2024; and <i>re/de/constructed language</i>, Spoke Gallery, Boston, USA, 2022. </p>
 
             <p>Coolidge has worked as a teaching fellow in the Art, Film, and Visual Studies department at Harvard University, has been a Curatorial Research Fellow at the MIT List Visual Arts Center, and has held residencies at the Vermont Studio Center and the Salzburg International Summer Academy of Fine Arts. She completed her undergraduate studies at Harvard College in 2022 and earned a Master of Fine Arts with distinction from the Ruskin School of Art, University of Oxford, in 2024.</p>
+            <p>Contact: studio@carolinecoolidge.com</p>
         </div>
     </div>
 
-    <div class="about-credits" style="display: none;">
-        <p class="about-image-caption">Portrait by Deema Alghunaim, 2024.</p>
-        <p class="about-contact">Contact: studio@carolinecoolidge.com</p>
-    </div>
 
     <div class="lightbox" id="lightbox">
         <div class="close hamburger-menu" onclick="closeLightbox()">
@@ -462,7 +447,7 @@
         const aboutHamburgerMenu = document.querySelector(".menu .hamburger-menu");
         function showAbout() {
             $('#gallery').hide();
-            $('.about-content, .about-credits').show();
+            $('.about-content').show();
             
             document.querySelector("#aboutLink").classList.add("change");
             aboutHamburgerMenu.classList.add("change");
@@ -470,7 +455,7 @@
         }
         
         function showGallery() {
-            $('.about-content, .about-credits').hide();
+            $('.about-content').hide();
             $('#gallery').show();
             if (document.querySelector("#aboutLink").classList.contains("change")) {
                 document.querySelector("#aboutLink").classList.remove("change");


### PR DESCRIPTION
## Summary
- enlarge about page image and tweak caption spacing
- place caption below image
- move contact line inside about text
- remove unused credits markup and references

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6845d3a9f8f0832d94172b8a6cedfbce