### PR TITLE
Fix header spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
             font-size: 28px;
             /* font-weight: bold; */
             text-align: center;
-            margin-top: 10px;
+            margin-top: 16px;
         }
         #aboutLink {
             font-size: 16px;


### PR DESCRIPTION
## Summary
- adjust the name element's margin to give 16px space between the About link and "Caroline Coolidge"

## Testing
- `npx htmlhint index.html` *(fails: requires network to install)*

------
https://chatgpt.com/codex/tasks/task_e_6845d99c7600832d9c8ed64df3a7785e